### PR TITLE
Allow startup with empty urdf

### DIFF
--- a/controller_manager/include/controller_manager/controller_manager.hpp
+++ b/controller_manager/include/controller_manager/controller_manager.hpp
@@ -40,6 +40,8 @@
 #include "controller_manager_msgs/srv/switch_controller.hpp"
 #include "controller_manager_msgs/srv/unload_controller.hpp"
 
+#include "std_msgs/msg/string.hpp"
+
 #include "diagnostic_updater/diagnostic_updater.hpp"
 #include "hardware_interface/handle.hpp"
 #include "hardware_interface/resource_manager.hpp"
@@ -51,6 +53,7 @@
 #include "rclcpp/node_interfaces/node_logging_interface.hpp"
 #include "rclcpp/node_interfaces/node_parameters_interface.hpp"
 #include "rclcpp/parameter.hpp"
+#include "rclcpp/rclcpp.hpp"
 
 namespace controller_manager
 {
@@ -81,6 +84,9 @@ public:
   CONTROLLER_MANAGER_PUBLIC
   void init_resource_manager(const std::string & robot_description);
 
+  CONTROLLER_MANAGER_PUBLIC
+  void init_resource_manager_cb(const std_msgs::msg::String & msg);
+  
   CONTROLLER_MANAGER_PUBLIC
   controller_interface::ControllerInterfaceBaseSharedPtr load_controller(
     const std::string & controller_name, const std::string & controller_type);
@@ -496,6 +502,8 @@ private:
   std::vector<std::string> to_chained_mode_request_, from_chained_mode_request_;
   std::vector<std::string> activate_command_interface_request_,
     deactivate_command_interface_request_;
+
+  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr robot_description_subscription_;
 
   struct SwitchParams
   {

--- a/controller_manager/include/controller_manager/controller_manager.hpp
+++ b/controller_manager/include/controller_manager/controller_manager.hpp
@@ -15,6 +15,7 @@
 #ifndef CONTROLLER_MANAGER__CONTROLLER_MANAGER_HPP_
 #define CONTROLLER_MANAGER__CONTROLLER_MANAGER_HPP_
 
+#include <chrono>
 #include <map>
 #include <memory>
 #include <string>
@@ -84,9 +85,6 @@ public:
   CONTROLLER_MANAGER_PUBLIC
   void init_resource_manager(const std::string & robot_description);
 
-  CONTROLLER_MANAGER_PUBLIC
-  void init_resource_manager_cb(const std_msgs::msg::String & msg);
-  
   CONTROLLER_MANAGER_PUBLIC
   controller_interface::ControllerInterfaceBaseSharedPtr load_controller(
     const std::string & controller_name, const std::string & controller_type);
@@ -195,6 +193,9 @@ public:
 protected:
   CONTROLLER_MANAGER_PUBLIC
   void init_services();
+
+  CONTROLLER_MANAGER_PUBLIC
+  void wait_for_robot_description();
 
   CONTROLLER_MANAGER_PUBLIC
   controller_interface::ControllerInterfaceBaseSharedPtr add_controller_impl(
@@ -307,12 +308,17 @@ protected:
     const std::shared_ptr<controller_manager_msgs::srv::SetHardwareComponentState::Request> request,
     std::shared_ptr<controller_manager_msgs::srv::SetHardwareComponentState::Response> response);
 
+  CONTROLLER_MANAGER_PUBLIC
+  void init_resource_manager_cb(const std_msgs::msg::String & msg);
+
   // Per controller update rate support
   unsigned int update_loop_counter_ = 0;
   unsigned int update_rate_ = 100;
   std::vector<std::vector<std::string>> chained_controllers_configuration_;
 
   std::unique_ptr<hardware_interface::ResourceManager> resource_manager_;
+
+  int64_t wait_for_robot_description_ = 10;
 
 private:
   std::vector<std::string> get_controller_names();


### PR DESCRIPTION
What has been done:
* Deprecate passing of robot description file to controller manager
* subscribe to robot_state_publisher to get robot_description_file

Things to consider:
* Controllers are in unconfigured state this way and have to be configured and activated.