### PR TITLE
Slave-mode ros2_control node

### DIFF
--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -3424,6 +3424,10 @@ void ControllerManager::write(const rclcpp::Time & time, const rclcpp::Duration 
       .count();
   execution_time_.total_time =
     execution_time_.write_time + execution_time_.update_time + execution_time_.read_time;
+
+  PUBLISH_ROS2_CONTROL_INTROSPECTION_DATA_ASYNC(hardware_interface::CM_STATISTICS_KEY);
+  if(params_->slave_mode) return;
+  
   const double expected_cycle_time = 1.e6 / static_cast<double>(get_update_rate());
   if (params_->overruns.print_warnings && execution_time_.total_time > expected_cycle_time)
   {
@@ -3451,8 +3455,6 @@ void ControllerManager::write(const rclcpp::Time & time, const rclcpp::Duration 
         execution_time_.update_time, execution_time_.write_time);
     }
   }
-
-  PUBLISH_ROS2_CONTROL_INTROSPECTION_DATA_ASYNC(hardware_interface::CM_STATISTICS_KEY);
 }
 
 std::vector<ControllerSpec> &

--- a/controller_manager/src/controller_manager_parameters.yaml
+++ b/controller_manager/src/controller_manager_parameters.yaml
@@ -265,5 +265,6 @@ controller_manager:
     }
   slave_mode: {
       type: bool,
+      default_value: false,
       description: "If true, the controller manager will schedule its own update loop, targeting the ``update_rate``. It will rely on blocking ``read()`` in a hardware interface to provide this scheduling. By default it is set to false.",
     }

--- a/controller_manager/src/controller_manager_parameters.yaml
+++ b/controller_manager/src/controller_manager_parameters.yaml
@@ -263,3 +263,7 @@ controller_manager:
       type: bool,
       description: "If true, the controller manager will print a warning message to the console if an overrun is detected in its real-time loop (``read``, ``update`` and ``write``). By default, it is set to true, except when used with ``use_sim_time`` parameter set to true.",
     }
+  slave_mode: {
+      type: bool,
+      description: "If true, the controller manager will schedule its own update loop, targeting the ``update_rate``. It will rely on blocking ``read()`` in a hardware interface to provide this scheduling. By default it is set to false.",
+    }

--- a/controller_manager/src/ros2_control_node.cpp
+++ b/controller_manager/src/ros2_control_node.cpp
@@ -58,6 +58,7 @@ int main(int argc, char ** argv)
     executor, manager_node_name, "", cm_node_options);
 
   const bool use_sim_time = cm->get_parameter_or("use_sim_time", false);
+  
 
   const bool has_realtime = realtime_tools::has_realtime_kernel();
   const bool lock_memory = cm->get_parameter_or<bool>("lock_memory", has_realtime);
@@ -71,16 +72,21 @@ int main(int argc, char ** argv)
   }
 
   RCLCPP_INFO(cm->get_logger(), "update rate is %d Hz", cm->get_update_rate());
+  const bool slave_mode = cm->get_parameter_or("slave_mode", true);
+  RCLCPP_INFO(cm->get_logger(), "Slave mode: %s. Controller Manager relies on robot blocking read() to synchronize the update loop.", slave_mode ? "enabled " : "disabled");
+
   const bool manage_overruns = cm->get_parameter_or<bool>("overruns.manage", true);
-  RCLCPP_INFO(
-    cm->get_logger(), "Overruns handling is : %s", manage_overruns ? "enabled" : "disabled");
+  if (!slave_mode) {
+    RCLCPP_INFO(
+        cm->get_logger(), "Overruns handling is : %s", manage_overruns ? "enabled" : "disabled");
+  }
   const int thread_priority = cm->get_parameter_or<int>("thread_priority", kSchedPriority);
   RCLCPP_INFO(
     cm->get_logger(), "Spawning %s RT thread with scheduler priority: %d", cm->get_name(),
     thread_priority);
 
   std::thread cm_thread(
-    [cm, thread_priority, use_sim_time, manage_overruns]()
+    [cm, thread_priority, use_sim_time, manage_overruns, slave_mode]()
     {
       rclcpp::Parameter cpu_affinity_param;
       if (cm->get_parameter("cpu_affinity", cpu_affinity_param))
@@ -152,7 +158,7 @@ int main(int argc, char ** argv)
         {
           cm->get_clock()->sleep_until(current_time + period);
         }
-        else
+        else if(!slave_mode)
         {
           next_iteration_time += period;
           const auto time_now = std::chrono::steady_clock::now();

--- a/controller_manager/src/ros2_control_node.cpp
+++ b/controller_manager/src/ros2_control_node.cpp
@@ -70,15 +70,17 @@ int main(int argc, char ** argv)
       RCLCPP_WARN(cm->get_logger(), "Unable to lock the memory: '%s'", lock_result.second.c_str());
     }
   }
-
-  RCLCPP_INFO(cm->get_logger(), "update rate is %d Hz", cm->get_update_rate());
-  const bool slave_mode = cm->get_parameter_or("slave_mode", true);
-  RCLCPP_INFO(cm->get_logger(), "Slave mode: %s. Controller Manager relies on robot blocking read() to synchronize the update loop.", slave_mode ? "enabled " : "disabled");
-
+  
+  const bool slave_mode = cm->get_parameter_or("slave_mode", false);
   const bool manage_overruns = cm->get_parameter_or<bool>("overruns.manage", true);
+
   if (!slave_mode) {
+    RCLCPP_INFO(cm->get_logger(), "update rate is %d Hz", cm->get_update_rate());
     RCLCPP_INFO(
         cm->get_logger(), "Overruns handling is : %s", manage_overruns ? "enabled" : "disabled");
+  } else {
+    RCLCPP_INFO(
+        cm->get_logger(), "SLAVE mode ENABLED. Controller Manager relies on robot blocking read() to synchronize the update loop.");
   }
   const int thread_priority = cm->get_parameter_or<int>("thread_priority", kSchedPriority);
   RCLCPP_INFO(

--- a/controller_manager/src/ros2_control_node.cpp
+++ b/controller_manager/src/ros2_control_node.cpp
@@ -71,7 +71,7 @@ int main(int argc, char ** argv)
     }
   }
   
-  const bool slave_mode = cm->get_parameter_or("slave_mode", false);
+  const bool slave_mode = cm->get_parameter_or<bool>("slave_mode", false);
   const bool manage_overruns = cm->get_parameter_or<bool>("overruns.manage", true);
 
   if (!slave_mode) {


### PR DESCRIPTION
If true, we skip sleep, relying on blocking read() from robot.

This is a draft showcasing the benefits of the approach. Currently only can run a single hardware interface in this mode.